### PR TITLE
align pointer syntax

### DIFF
--- a/dictionary.h
+++ b/dictionary.h
@@ -23,11 +23,11 @@
 typedef struct node
 {
     char word[LENGTH + 1];
-    struct node* next;
+    struct node *next;
 }
 node;
 
-typedef node* hashmap_t;
+typedef node *hashmap_t;
 
 /**
  * Array misspelled is populated with words that are misspelled. Returns the length of misspelled.
@@ -48,7 +48,7 @@ typedef node* hashmap_t;
  * Example:
  *  int num_misspelled = check_words(text_file, hashtable, misspelled);
  **/
-int check_words(FILE* fp, hashmap_t hashtable[], char * misspelled[]);
+int check_words(FILE *fp, hashmap_t hashtable[], char *misspelled[]);
 
 /**
  * Returns true if word is in dictionary else false.
@@ -66,7 +66,7 @@ int check_words(FILE* fp, hashmap_t hashtable[], char * misspelled[]);
  * Example:
  *  bool correct  = check_word(word, hashtable);
  **/
-bool check_word(const char* word, hashmap_t hashtable[]);
+bool check_word(const char *word, hashmap_t hashtable[]);
 
 /**
  * Loads dictionary into memory.  Returns true if successful else false.
@@ -85,6 +85,6 @@ bool check_word(const char* word, hashmap_t hashtable[]);
  * Example:
  *  bool success = load_dictionary("wordlist.txt", hashtable);
  **/
-bool load_dictionary(const char* dictionary_file, hashmap_t hashtable[]);
+bool load_dictionary(const char *dictionary_file, hashmap_t hashtable[]);
 
 #endif // DICTIONARY_H


### PR DESCRIPTION
There was a discrepancy between the `Assignment 1-1.pdf` and this `file` for the `misspelled[] pointer` syntax:

The syntax error:
```
int check_words(FILE* fp, hashmap_t hashtable[], **char * misspelled[]**);
```
The alternative from the pdf:
```
int check_words(FILE* fp, hashmap_t hashtable[], **char* misspelled[]**);
```

This led me to lookup a style guide suggestion to align them to a preferred choice. The style guides recommended a third option, however, to place the asterisk next to the variable such as **char *misspelled[]** https://www.maultech.com/chrislott/resources/cstyle/indhill-cstyle.html and https://www.doc.ic.ac.uk/lab/cplus/cstyle.html

I've edited the pointers in this file to be consistent and match the suggested style.